### PR TITLE
add correct branch to github action trigger

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - production
+      - master
 
 jobs:
   main:


### PR DESCRIPTION
We don't have a production branch yet. So the github action will never trigger as it is written. 