### PR TITLE
Handle backslashes in filepath

### DIFF
--- a/update_employees.py
+++ b/update_employees.py
@@ -303,8 +303,6 @@ def main():
     KNACK_APP_ID = os.getenv("KNACK_APP_ID")
     KNACK_API_KEY = os.getenv("KNACK_API_KEY")
 
-    logging.info(f'does this work')
-
     records_hr_banner = get_employee_data()
     employee_emails = get_emails_data()
     records_hr_emails = update_emails(records_hr_banner, employee_emails)

--- a/update_employees.py
+++ b/update_employees.py
@@ -18,6 +18,7 @@ import wddx
 import smbclient
 
 
+
 def parse_name(full_name):
     name_parts = full_name.split(",")
     return {"first": name_parts[1].strip(), "last": name_parts[0].strip()}
@@ -89,7 +90,9 @@ def get_emails_data():
 
     smbclient.ClientConfig(username=os.getenv("SHAREDDRIVE_USERNAME"), password=os.getenv("SHAREDDRIVE_PASSWORD"))
 
-    emails_csv = os.getenv("SHAREDDRIVE_FILEPATH")
+    emails_csv_path = os.getenv("SHAREDDRIVE_FILEPATH")
+    # variables stored in json objects do not work well with \, replace / in stored path with \
+    emails_csv = emails_csv_path.replace("/", "\\")
     with smbclient.open_file(emails_csv, mode='r') as emails:
         reader = csv.DictReader(emails)
         data = [row for row in reader]


### PR DESCRIPTION
Airflow stores our variables in json objects and the filepath for the shared drive contains many `\` which is causing airflow to throw malformed dag errors. 

I changed the variable in airflow to have `/` (and this time validated the json before saving), so I'm updating the knack banner script to switch the `/` back to `\`

I saw online that some windows machines will accept `/` in place of `\` but I tried testing different variations of the filepath and the samba client at least wants the `\`