### PR TITLE
7367 payload enhancements

### DIFF
--- a/update_employees.py
+++ b/update_employees.py
@@ -12,14 +12,14 @@ import string
 import sys
 import csv
 from datetime import date
-import calendar
 
 import knackpy
 import requests
 import wddx
 import smbclient
 
-months_dict = {name: num for num, name in enumerate(calendar.month_name) if num}
+months_dict = {'January': '01', 'February': '02', 'March': '03', 'April': '04', 'May': '05', 'June': '06', 'July': '07',
+               'August': '08', 'September': '09', 'October': '10', 'November': '11', 'December': '12'}
 today = date.today().strftime("%/%d/%Y")
 
 
@@ -40,7 +40,7 @@ def format_date(val):
     # dates in banner are in this format "January, 19 1999 00:00:00"
     date_pieces = val.split()
     month = months_dict[date_pieces[0][:-1]]
-    return f"{month}/{date_pieces[1]}/{date_pieces[2]}"
+    return {"date": f"{month}/{date_pieces[1]}/{date_pieces[2]}"}
 
 
 FIELD_MAP = [
@@ -56,14 +56,16 @@ FIELD_MAP = [
     {"banner": "hiredate", "dts_portal": "", "hr": "field_260", "handler": format_date}
 ]
 
+NAME_FIELD = {"hr": "field_17"}
 PASSWORD_FIELD = {"hr": "field_19", "dts_portal": ""}
 USER_STATUS_FIELD = {"hr": "field_20", "dts_portal": ""}
 EMAIL_FIELD = {"hr": "field_18", "dts_portal": ""}
-# CREATED_DATE = {"hr": "field_267"}
-CREATED_DATE = {"hr": "field_259"} #todo: remove test version
-CLASS = {"hr": "field_95"}
-# SEPARATED = {"hr": "field_402"}
-SEPARATED = {"hr": "field_261"}
+# CREATED_DATE_FIELD = {"hr": "field_267"}
+CREATED_DATE_FIELD = {"hr": "field_259"} #todo: remove test version
+CLASS_FIELD = {"hr": "field_95"}
+# SEPARATED_FIELD = {"hr": "field_402"}
+SEPARATED_FIELD = {"hr": "field_261"}
+USER_ROLE_FIELD = {"hr": "field_21"}
 ACCOUNTS_OBJS = {"hr": "object_5"}
 
 
@@ -203,7 +205,7 @@ def is_different(record_hr, record_knack):
 
 
 def build_payload(records_knack, records_hr, pk_field, status_field, password_field, created_date_field, class_field,
-                  separated_field):
+                  separated_field, user_role_field):
     """
     compare the hr records against knack records and return those records which
     are different or are new
@@ -213,6 +215,9 @@ def build_payload(records_knack, records_hr, pk_field, status_field, password_fi
     :param status_field: field name for status field in knack app
     :param password_field: field for password in knack app
     :param created_date_field: field for created date in knack app
+    :param class_field: field for class in knack app
+    :param separated_field: field if employee is separated in knack app
+    :param user_role_field: field in knack app to specify Staff, Supervisor etc
     :return:
     """
     payload = []
@@ -228,7 +233,7 @@ def build_payload(records_knack, records_hr, pk_field, status_field, password_fi
                 r_hr["id"] = r_knack["id"]
                 # Check if user is marked as inactive in knack
                 # and update status_field to active since they are in banner
-                if r_knack[status_field] == "inactive" and r_knack[separated_field] != 'Yes':
+                if r_knack[status_field] == "inactive" and not r_knack[separated_field]:
                     r_hr[status_field] = "active"
                 # if any of the fields differ, add banner record to payload
                 if is_different(r_hr, r_knack):
@@ -242,6 +247,8 @@ def build_payload(records_knack, records_hr, pk_field, status_field, password_fi
             # Knack's default user status is inactive. so set new users' status to active
             r_hr[status_field] = "active"
             r_hr[created_date_field] = today
+            # set all new users as "Staff", which is profile_7 in knack HR app
+            r_hr[user_role_field] = ["profile_7"]
             payload.append(r_hr)
 
     inactivate = 0
@@ -292,11 +299,12 @@ def set_passwords(records, password_field):
     return
 
 
-def remove_empty_emails(payload, email_field):
+def remove_empty_emails(payload, email_field, name_field):
     """
     Knack won't allow records to be added without valid emails
     :param payload: list of records payload
     :param email_field: email field to check from knack app
+    :param name_field: name field for easier to read logging
     :return: list of payload records with valid emails
     """
     cleaned_payload = []
@@ -304,6 +312,7 @@ def remove_empty_emails(payload, email_field):
         try:
             if r[email_field]["email"] != "no email":
                 cleaned_payload.append(r)
+                logging.info(f"Updating {r[name_field]}")
         except KeyError:
             # if an item in the payload doesn't have an email
             # that payload item is being set as inactive
@@ -338,12 +347,14 @@ def main():
     status_field = USER_STATUS_FIELD[KNACK_APP_NAME]
     password_field = PASSWORD_FIELD[KNACK_APP_NAME]
     email_field = EMAIL_FIELD[KNACK_APP_NAME]
-    created_date_field = CREATED_DATE[KNACK_APP_NAME]
-    class_field = CLASS[KNACK_APP_NAME]
-    separated_field = SEPARATED[KNACK_APP_NAME]
+    created_date_field = CREATED_DATE_FIELD[KNACK_APP_NAME]
+    class_field = CLASS_FIELD[KNACK_APP_NAME]
+    separated_field = SEPARATED_FIELD[KNACK_APP_NAME]
+    name_field = NAME_FIELD[KNACK_APP_NAME]
+    user_role_field =  USER_ROLE_FIELD[KNACK_APP_NAME]
     payload = build_payload(records_knack, records_mapped, pk_field, status_field, password_field, created_date_field,
-                            class_field, separated_field)
-    cleaned_payload = remove_empty_emails(payload, email_field)
+                            class_field, separated_field, user_role_field)
+    cleaned_payload = remove_empty_emails(payload, email_field, name_field)
 
     logging.info(f"{len(cleaned_payload)} total records to process in Knack.")
 

--- a/update_employees.py
+++ b/update_employees.py
@@ -60,9 +60,11 @@ PASSWORD_FIELD = {"hr": "field_19", "dts_portal": ""}
 USER_STATUS_FIELD = {"hr": "field_20", "dts_portal": ""}
 EMAIL_FIELD = {"hr": "field_18", "dts_portal": ""}
 # CREATED_DATE = {"hr": "field_267"}
-CREATED_DATE = {"hr": "field_259"}
+CREATED_DATE = {"hr": "field_259"} #todo: remove test version
+CLASS = {"hr": "field_95"}
+# SEPARATED = {"hr": "field_402"}
+SEPARATED = {"hr": "field_261"}
 ACCOUNTS_OBJS = {"hr": "object_5"}
-
 
 
 def drop_empty_positions(records_hr, key="pidm"):
@@ -200,7 +202,8 @@ def is_different(record_hr, record_knack):
     return False
 
 
-def build_payload(records_knack, records_hr, pk_field, status_field, password_field, created_date_field):
+def build_payload(records_knack, records_hr, pk_field, status_field, password_field, created_date_field, class_field,
+                  separated_field):
     """
     compare the hr records against knack records and return those records which
     are different or are new
@@ -225,7 +228,7 @@ def build_payload(records_knack, records_hr, pk_field, status_field, password_fi
                 r_hr["id"] = r_knack["id"]
                 # Check if user is marked as inactive in knack
                 # and update status_field to active since they are in banner
-                if r_knack[status_field] == "inactive":
+                if r_knack[status_field] == "inactive" and r_knack[separated_field] != 'Yes':
                     r_hr[status_field] = "active"
                 # if any of the fields differ, add banner record to payload
                 if is_different(r_hr, r_knack):
@@ -251,7 +254,7 @@ def build_payload(records_knack, records_hr, pk_field, status_field, password_fi
             if pk_hr == pk_knack:
                 matched = True
                 break
-        if not matched and r_knack[status_field] != "inactive":
+        if not matched and r_knack[status_field] != "inactive" and r_knack[class_field] != "Contract":
             record_id = r_knack["id"]
             inactivate = inactivate + 1
             payload.append({"id": record_id, status_field: "inactive"})
@@ -336,7 +339,10 @@ def main():
     password_field = PASSWORD_FIELD[KNACK_APP_NAME]
     email_field = EMAIL_FIELD[KNACK_APP_NAME]
     created_date_field = CREATED_DATE[KNACK_APP_NAME]
-    payload = build_payload(records_knack, records_mapped, pk_field, status_field, password_field, created_date_field)
+    class_field = CLASS[KNACK_APP_NAME]
+    separated_field = SEPARATED[KNACK_APP_NAME]
+    payload = build_payload(records_knack, records_mapped, pk_field, status_field, password_field, created_date_field,
+                            class_field, separated_field)
     cleaned_payload = remove_empty_emails(payload, email_field)
 
     logging.info(f"{len(cleaned_payload)} total records to process in Knack.")

--- a/update_employees.py
+++ b/update_employees.py
@@ -18,7 +18,6 @@ import wddx
 import smbclient
 
 
-
 def parse_name(full_name):
     name_parts = full_name.split(",")
     return {"first": name_parts[1].strip(), "last": name_parts[0].strip()}
@@ -122,7 +121,7 @@ def update_emails(records_hr, employee_emails):
         pk_hr = r_hr["pidm"]
         try:
             employee = employee_emails[str(pk_hr)]
-            if r_hr["email"] != employee["email"]:
+            if r_hr["email"] != employee["email"] and len(employee["email"]) > 0:
                 r_hr["email"] = employee["email"]
         except KeyError:
             in_banner_no_email = in_banner_no_email + 1


### PR DESCRIPTION
adds some checks and enhancements:
- checks if email in ctm spreadsheet is not an empty string
- adds today's date as created by date, and user role as Staff for new records
- includes employees hiredate from banner
- if employee is in knack but not banner, do not mark as inactive if they are a contractor
- if an employee is still in banner but has been separated from the city, do not mark as active
- Logs the employees name if they have been added to the payload to send to knack