### PR TITLE
7476 - More email fixes

### DIFF
--- a/update_employees.py
+++ b/update_employees.py
@@ -308,9 +308,9 @@ def build_payload(
                 # if any of the fields differ, add banner record to payload
                 if is_different(r_hr, r_knack):
                     if r_hr[email_field]["email"] == "no email":
-                        r_hr[email_field]["email"] = create_placeholder_email(
-                            r_hr, name_field
-                        )
+                        # If banner and CTM do not have emails for a user in knack, use the knack record email
+                        # record should still be added to payload in case other fields also differ
+                        r_hr[email_field]["email"] = r_knack[email_field]["email"]
                     payload.append(r_hr)
                 break
         # employee id number not in knack records


### PR DESCRIPTION
A few more refinements

- an employee with a middle initial did not have an email, which the placeholder function was including the middle initial ex: `first m..last@austintexas.gov`. Refined it to ignore middle initial 
- Also realized that if someone has manually corrected the missing email in knack, my script was overwriting it with the placeholder email. Now the placeholder email is only included if its a new record, if its an existing knack record, use the email from knack. 