### PR TITLE
disable all the smbprotocol logging

### DIFF
--- a/update_employees.py
+++ b/update_employees.py
@@ -33,7 +33,7 @@ months_dict = {
     "November": "11",
     "December": "12",
 }
-today = date.today().strftime("%/%d/%Y")
+today = date.today().strftime("%m/%d/%Y")
 
 
 def parse_name(full_name):
@@ -474,11 +474,18 @@ def main():
                 raise e
 
     logging.info(f"Update complete. {len(result['errors'])} errors.")
+    logging.info(result)
     return result
 
 
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logging.getLogger("smbprotocol").disabled = True
+    logging.getLogger("smbprotocol.transport").disabled = True
+    logging.getLogger("smbprotocol.open").disabled = True
+    logging.getLogger("smbprotocol.session").disabled = True
+    logging.getLogger("smbprotocol.connection").disabled = True
+    logging.getLogger("smbprotocol.tree").disabled = True
     script_result = main()
     if script_result["errors"]:
         raise Exception("".join(script_result["errors"]))


### PR DESCRIPTION
Previously I was trying to be fancy and get a dict with all the updates, so I could then use prefect to get the dict and send an email. 

That was not working the way I was hoping to get it to work. So instead, I'm just going to email the logs the script produces. Which means I need to quiet the very chatty smbprotocol loggers. 

I tested this by building this as the docker image tagged latest, and running my prefect script using that docker image instead of production. It didn't stdout any of the smbprotocol.* logs