### PR TITLE
Strip empty spaces out of emails

### DIFF
--- a/update_employees.py
+++ b/update_employees.py
@@ -200,6 +200,7 @@ def create_placeholder_email(record, name_field):
     # first name in some records includes middle initial, we only want the first name
     first_name = record[name_field]["first"].split()[0]
     email = f"{first_name}.{record[name_field]['last']}@austintexas.gov"
+    email = email.replace(' ', '')
     logging.info(f"setting placeholder email {email}")
     return email
 


### PR DESCRIPTION
    Emails are required for Knack records. We can guess a temporary email for a user so they can be added to knack

The guess email is first name +  last name, however I did not anticipate spaces in last names or first names. Which are not legitimate emails. 