### PR TITLE
Ignores knack/banner email differences under certain conditions

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - production
+  workflow_dispatch:
 
 jobs:
   main:

--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -11,20 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/atd-knack-banner:production
-            ${{ secrets.DOCKER_USERNAME }}/atd-knack-banner:staging
-            ${{ secrets.DOCKER_USERNAME }}/atd-knack-banner:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/update_employees.py
+++ b/update_employees.py
@@ -308,7 +308,8 @@ def build_payload(
         ):
             record_id = r_knack["id"]
             inactivate = inactivate + 1
-            payload.append({"id": record_id, status_field: "inactive"})
+            # we include the email field in the payload only for logging purposes
+            payload.append({"id": record_id, status_field: "inactive", email_field: r_knack[email_field] })
             result["inactivate"].append(r_knack[name_field])
 
     logging.info(f"{inactivate} records to mark inactive.")


### PR DESCRIPTION
This addresses an issue that became a problem now that we have 700+ more employees to handle, and also because we [no longer have a CTM data source for email addresses](https://github.com/cityofaustin/atd-knack-banner/pull/12).

Prior to this change, if an employee did not have an email address in Banner, the script would detect a change to that employee in Banner every time the script ran, because we create a placeholder email address in Knack when there is no email in Banner. The result was that our script would needlessly attempt to update ~180 employees every time it ran.

With this change, the script will not detect a change between two email addresses if the incoming record has `no email` and the existing Knack record has any email address other than `no email`.

Steps to test:
You'll need to connect to vpn, create an env file, and then you can mount this branch into the production docker image and run the script. You can locate the env vars in 1pass by referencing [the Airflow DAG](https://github.com/cityofaustin/atd-airflow/pull/149/files).

```
docker run -it --rm --env-file env_file -v ${PWD}:/app atddocker/atd-knack-banner:production ./update_employees.py
```
