### PR TITLE
Fix Banner integration is failing due to accounts missing email addresses

### DIFF
--- a/.github/workflows/docker-image-build-push.yml
+++ b/.github/workflows/docker-image-build-push.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.13-slim
 
 # Copy our own application
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.10-slim
 
 # Copy our own application
 WORKDIR /app

--- a/update_employees.py
+++ b/update_employees.py
@@ -194,6 +194,10 @@ def handle_empty_strings(records_hr_banner):
                 record[key] = None
 
 
+def drop_knack_system_records(records_knack, email_field):
+    return [r for r in records_knack if r.get(email_field).get("email")]
+
+
 def is_different(record_hr, record_knack):
     """
     compare records by comparing field values
@@ -361,7 +365,7 @@ def format_errors(error_list, record):
     """generate an error report that will be mildly readable in an email"""
     msgs = "\n".join([e["message"] for e in error_list])
     record_props = "\n".join([str(v) for v in record.values()])
-    return f"Error(s):\n{msgs}\n\nData:\n{record_props}\n\n"
+    return f"Error(s):{msgs}\n\nData:\n{record_props}\n\n"
 
 
 def main():
@@ -369,23 +373,6 @@ def main():
     KNACK_API_KEY = os.getenv("KNACK_API_KEY")
 
     result = {}
-
-    logging.info("Getting employee data from Banner...")
-    records_hr_banner = get_employee_data()
-
-    logging.info(f"Received {len(records_hr_banner)} records from Banner.")
-
-    records_hr_banner = drop_empty_positions(records_hr_banner)
-    handle_empty_strings(records_hr_banner)
-    records_mapped = map_records(records_hr_banner, FIELD_MAP, KNACK_APP_NAME)
-
-    # use knackpy to get records from knack hr object
-    knack_obj = ACCOUNTS_OBJS[KNACK_APP_NAME]
-    logging.info(f"Initializing Knack app...")
-    app = knackpy.App(app_id=KNACK_APP_ID, api_key=KNACK_API_KEY)
-    logging.info(f"Getting employee data from Knack app...")
-    records_knack = app.get(knack_obj)
-    logging.info(f"Got {len(records_knack)} records from Knack.")
 
     pk_field = get_primary_key_field(FIELD_MAP, KNACK_APP_NAME)
     status_field = USER_STATUS_FIELD[KNACK_APP_NAME]
@@ -396,6 +383,23 @@ def main():
     separated_field = SEPARATED_FIELD[KNACK_APP_NAME]
     name_field = NAME_FIELD[KNACK_APP_NAME]
     user_role_field = USER_ROLE_FIELD[KNACK_APP_NAME]
+
+    logging.info("Getting employee data from Banner...")
+    records_hr_banner = get_employee_data()
+    records_hr_banner = drop_empty_positions(records_hr_banner)
+    logging.info(f"Received {len(records_hr_banner)} records from Banner.")
+
+    handle_empty_strings(records_hr_banner)
+    records_mapped = map_records(records_hr_banner, FIELD_MAP, KNACK_APP_NAME)
+
+    # use knackpy to get records from knack hr object
+    knack_obj = ACCOUNTS_OBJS[KNACK_APP_NAME]
+    logging.info(f"Initializing Knack app...")
+    app = knackpy.App(app_id=KNACK_APP_ID, api_key=KNACK_API_KEY)
+    logging.info(f"Getting employee data from Knack app...")
+    records_knack = app.get(knack_obj)
+    records_knack = drop_knack_system_records(records_knack, email_field)
+    logging.info(f"Received {len(records_knack)} records from Knack.")
 
     payload = build_payload(
         records_knack,
@@ -416,7 +420,9 @@ def main():
     result["updates"] = [record for record in payload if record.get("id")]
     result["errors"] = []
 
-    logging.info(f"{len(result['additions'])} additions and {len(result['updates'])} updates to process in Knack.")
+    logging.info(
+        f"{len(result['additions'])} additions and {len(result['updates'])} updates to process in Knack."
+    )
 
     for record in payload:
         method = "update" if record.get("id") else "create"

--- a/update_employees.py
+++ b/update_employees.py
@@ -200,7 +200,11 @@ def drop_knack_system_records(records_knack, email_field):
     The account email fields have labels but no email, for example:
         {'email': None, 'label': '[System] Knack AI'}
     """
-    return [r for r in records_knack if r.get(email_field).get("email")]
+    return [
+        r
+        for r in records_knack
+        if r.get(email_field) and r.get(email_field).get("email")
+    ]
 
 
 def is_different(record_hr, record_knack):

--- a/update_employees.py
+++ b/update_employees.py
@@ -195,6 +195,11 @@ def handle_empty_strings(records_hr_banner):
 
 
 def drop_knack_system_records(records_knack, email_field):
+    """
+    Knack added system controlled user accounts that we cannot edit.
+    The account email fields have labels but no email, for example:
+        {'email': None, 'label': '[System] Knack AI'}
+    """
     return [r for r in records_knack if r.get(email_field).get("email")]
 
 

--- a/update_employees.py
+++ b/update_employees.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-Get employee data from the human resource system (Banner) and update records in Knack
-apps.
+Get employee data from the human resource system (Banner) and update records in Knack HR
+app.
 
 docker run -it --rm --env-file env_file \
     -v ${PWD}:/app \
@@ -359,10 +359,9 @@ def set_passwords(records, password_field):
 
 def format_errors(error_list, record):
     """generate an error report that will be mildly readable in an email"""
-    separator = "-" * 10
     msgs = "\n".join([e["message"] for e in error_list])
     record_props = "\n".join([str(v) for v in record.values()])
-    return f"{separator}\nError(s):\n{msgs}\n\nData:\n{record_props}\n\n"
+    return f"Error(s):\n{msgs}\n\nData:\n{record_props}\n\n"
 
 
 def main():
@@ -374,7 +373,7 @@ def main():
     logging.info("Getting employee data from Banner...")
     records_hr_banner = get_employee_data()
 
-    logging.info(f"Got {len(records_hr_banner)} records from Banner.")
+    logging.info(f"Received {len(records_hr_banner)} records from Banner.")
 
     records_hr_banner = drop_empty_positions(records_hr_banner)
     handle_empty_strings(records_hr_banner)


### PR DESCRIPTION
Addresses https://github.com/cityofaustin/atd-data-tech/issues/29685, where Knack added a handful of system accounts we cannot edit. And while I was here addresses https://github.com/cityofaustin/atd-data-tech/issues/29133, formatting the error message output to remove the `-----` and bumping github action versions. 

_edit_: I tried updating to python 3.14 but @mddilley caught during testing that it does not work. The error is `ModuleNotFoundError: No module named 'urllib3.packages.six.moves'`.  Python 3.10 works, so I am going to upgrade to that for now 

The system records we cannot edit are missing email addresses, but do have labels in the email field. So if we filtered on records where field_18 aka email field is "None", we don't get any records returned since there is a label. We need to drill down one more level to the email on the email field. 

```
{'email': None, 'label': '[System] Knack AI'}
{'email': None, 'label': '[System] Automation'}
{'email': None, 'label': '[System] App Builder'}
{'email': None, 'label': '[System] Shared Builder'}
{'email': None, 'label': '[System] Public (Not Logged-In)'}
{'email': None, 'label': '[System] Account Owner'}
{'email': None, 'label': '[System] Knack Support Team'}
{'email': None, 'label': '[System] System'}
```

To test:

Be on vpn to be able to access the Banner endpoint
Create your env file based on the template if you have not tested this previously. 
Then run the update_employees script.

```bash
docker run -it --rm --env-file env_file -v ${PWD}:/app atddocker/atd-knack-banner:production ./update_employees.py
```

Instead of getting errors about accounts missing email addresses that we cannot mark as inactive, you should now get just one error about a duplicate email account. I need to contact HR to address that upstream issue. 
